### PR TITLE
Align dependency pins and document dependency workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ pytest -m "ai_stub" --browser chromium -n auto
 
 > **Tip:** Without API keys or with `ENABLE_AGENT=false`, the framework automatically uses the deterministic stub provider, ensuring green CI runs.
 
+## Dependency Management
+
+- The canonical dependency definitions live in [`pyproject.toml`](pyproject.toml). Update runtime pins under `[project].dependencies` and developer tooling under `[project.optional-dependencies].dev`.
+- After editing `pyproject.toml`, regenerate lock files so the ad-hoc installers stay aligned:
+
+  ```bash
+  pip install pip-tools
+  pip-compile pyproject.toml --output-file requirements.txt
+  pip-compile --extra dev pyproject.toml --output-file requirements-dev.txt
+  ```
+
+- Validate both workflows with `python -m pip install -r requirements-dev.txt` and `python -m pip install -e .[dev]` to ensure they resolve the same packages (aside from the editable entry for the local project).
+
 ## Project Structure
 
 ```

--- a/agents/browser_agent.py
+++ b/agents/browser_agent.py
@@ -4,6 +4,7 @@ import json
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+
 from ai.providers import ProviderProtocol, get_provider
 from utils.logger import configure_logger
 from utils.settings import Settings, load_settings

--- a/ai/providers.py
+++ b/ai/providers.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from langchain_core.messages import HumanMessage
-from langchain_groq import ChatGroq
-from langchain_openai import ChatOpenAI
 
 from utils.logger import configure_logger, redact_secrets
 from utils.settings import Settings, load_settings

--- a/pages/saucedemo_inventory_page.py
+++ b/pages/saucedemo_inventory_page.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
-from playwright.sync_api import Page
+from playwright.sync_api import Locator, Page
 
 from utils.sauce_simulator import Product, SauceSimulator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,21 @@ readme = "README.md"
 requires-python = ">=3.12,<3.13"
 authors = [{ name = "Current User" }]
 dependencies = [
-  "playwright==1.44.0",
-  "pytest==8.2.1",
-  "pytest-xdist==3.5.0",
+  "playwright==1.55.0",
+  "pytest==8.4.2",
+  "pytest-xdist==3.8.0",
   "pytest-html==4.1.1",
-  "pytest-retry==1.6.3",
-  "pytest-rerunfailures==13.0",
+  "pytest-retry==1.7.0",
+  "pytest-rerunfailures==15.1",
   "pytest-metadata==3.0.0",
-  "pytest-playwright==0.4.4",
-  "playwright-axe==0.4.0",
+  "pytest-playwright==0.7.1",
+  "pytest-playwright-axe==4.10.3",
   "python-dotenv==1.0.1",
-  "pydantic==2.7.2",
-  "pydantic-settings==2.4.0",
-  "langchain==0.1.20",
-  "langchain-openai==0.1.7",
-  "langchain-groq==0.0.6",
+  "pydantic==2.7.4",
+  "pydantic-settings==2.11.0",
+  "langchain==0.3.27",
+  "langchain-openai==0.3.33",
+  "langchain-groq==0.3.8",
   "httpx==0.27.0",
   "requests==2.32.3",
   "aiofiles==23.2.1",
@@ -41,8 +41,20 @@ dev = [
   "black==24.4.2",
   "isort==5.13.2",
   "bandit==1.7.8",
+  "detect-secrets==1.4.0",
   "types-requests==2.32.0.20240523",
-  "types-jsonschema==4.22.0.20240512"
+  "types-jsonschema==4.20.0.0"
+]
+
+[tool.setuptools]
+packages = [
+  "agents",
+  "ai",
+  "configs",
+  "flows",
+  "fixtures",
+  "pages",
+  "utils"
 ]
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page

--- a/utils/sauce_simulator.py
+++ b/utils/sauce_simulator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
 
 
 @dataclass(frozen=True)
@@ -14,7 +13,7 @@ class Product:
 
 class SauceSimulator:
   def __init__(self) -> None:
-    self._inventory: List[Product] = [
+    self._inventory: list[Product] = [
       Product("Sauce Labs Backpack", 29.99),
       Product("Sauce Labs Bike Light", 9.99),
       Product("Sauce Labs Bolt T-Shirt", 15.99),
@@ -26,7 +25,7 @@ class SauceSimulator:
 
   def reset(self) -> None:
     self.cart: list[Product] = []
-    self.sorted_products: List[Product] = list(self._inventory)
+    self.sorted_products: list[Product] = list(self._inventory)
     self.logged_in = False
     self.checkout_message = ""
     self.error_message = ""
@@ -61,7 +60,7 @@ class SauceSimulator:
   def cart_badge(self) -> str:
     return str(len(self.cart))
 
-  def cart_names(self) -> List[str]:
+  def cart_names(self) -> list[str]:
     return [product.name for product in self.cart]
 
   def checkout(self) -> str:

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Any
 
-import tomllib
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, field_validator
 


### PR DESCRIPTION
## Summary
- update pyproject dependencies to match the modern pins used in requirements.txt and switch to pytest-playwright-axe
- sync the dev extra with requirements-dev.txt and configure setuptools package discovery for editable installs
- document the dependency management workflow so requirements files stay in sync with pyproject.toml

## Testing
- python -m pip install -r requirements-dev.txt
- python -m pip install -e .[dev]
- diff -u /tmp/requirements_install.txt /tmp/editable_install.txt


------
https://chatgpt.com/codex/tasks/task_e_68d7a3eee19c83209790cf6f3109e46c